### PR TITLE
Update the used SQL schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 ## Unreleased
 
+- [#15](https://github.com/kobsio/klogs/pull/15): Update the used SQL schema to use `ReplicatedMergeTree` instead of `MergeTree`.
+
 ## [v0.6.0](https://github.com/kobsio/klogs/releases/tag/v0.6.0) (2021-11-19)
 
 - [#11](https://github.com/kobsio/klogs/pull/11): Update Fluent Bit to version 1.8.9.

--- a/README.md
+++ b/README.md
@@ -18,31 +18,31 @@ The SQL schema for ClickHouse must be created on each ClickHouse node and looks 
 ```sql
 CREATE DATABASE IF NOT EXISTS logs ENGINE=Atomic;
 
-CREATE TABLE IF NOT EXISTS logs.logs_local(
-  timestamp DateTime64(3) CODEC(Delta, ZSTD(1)),
-  cluster LowCardinality(String) CODEC(ZSTD(1)),
-  namespace LowCardinality(String) CODEC(ZSTD(1)),
-  app String CODEC(ZSTD(1)),
-  pod_name String CODEC(ZSTD(1)),
-  container_name String CODEC(ZSTD(1)),
-  host String CODEC(ZSTD(1)),
-  fields_string Nested(key String, value String) CODEC(ZSTD(1)),
-  fields_number Nested(key String, value Float64) CODEC(ZSTD(1)),
-  log String CODEC(ZSTD(1))
-) ENGINE = MergeTree()
+CREATE TABLE IF NOT EXISTS logs.logs_local ON CLUSTER '{cluster}' (
+  timestamp DateTime64(3) CODEC (Delta, ZSTD(1)),
+  cluster LowCardinality(String) CODEC (ZSTD(1)),
+  namespace LowCardinality(String) CODEC (ZSTD(1)),
+  app String CODEC (ZSTD(1)),
+  pod_name String CODEC (ZSTD(1)),
+  container_name String CODEC (ZSTD(1)),
+  host String CODEC (ZSTD(1)),
+  fields_string Nested(key String, value String) CODEC (ZSTD(1)),
+  fields_number Nested(key String, value Float64) CODEC (ZSTD(1)),
+  log String CODEC (ZSTD(1))
+) ENGINE = ReplicatedMergeTree()
   TTL toDateTime(timestamp) + INTERVAL 30 DAY DELETE
   PARTITION BY toDate(timestamp)
   ORDER BY (cluster, namespace, app, pod_name, container_name, host, -toUnixTimestamp(timestamp));
 
-CREATE TABLE IF NOT EXISTS logs.logs AS logs.logs_local ENGINE = Distributed('{cluster}', logs, logs_local, cityHash64(cluster, namespace, app, pod_name, container_name, host));
+CREATE TABLE IF NOT EXISTS logs.logs ON CLUSTER '{cluster}' AS logs.logs_local ENGINE = Distributed('{cluster}', logs, logs_local, rand());
 ```
 
 To speedup queries for the most frequently queried fields we can materializing them to dedicated columns:
 
 ```sql
-ALTER TABLE logs.logs_local ADD COLUMN content.level String DEFAULT fields_string.value[indexOf(fields_string.key, 'content.level')]
-ALTER TABLE logs.logs ADD COLUMN content.level String DEFAULT fields_string.value[indexOf(fields_string.key, 'content.level')]
+ALTER TABLE logs.logs_local ON CLUSTER '{cluster}' ADD COLUMN content.level String DEFAULT fields_string.value[indexOf(fields_string.key, 'content.level')]
+ALTER TABLE logs.logs ON CLUSTER '{cluster}' ADD COLUMN content.level String DEFAULT fields_string.value[indexOf(fields_string.key, 'content.level')]
 
-ALTER TABLE logs.logs_local ADD COLUMN content.response_code Float64 DEFAULT fields_number.value[indexOf(fields_number.key, 'content.response_code')]
-ALTER TABLE logs.logs ADD COLUMN content.response_code Float64 DEFAULT fields_number.value[indexOf(fields_number.key, 'content.response_code')]
+ALTER TABLE logs.logs_local ON CLUSTER '{cluster}' ADD COLUMN content.response_code Float64 DEFAULT fields_number.value[indexOf(fields_number.key, 'content.response_code')]
+ALTER TABLE logs.logs ON CLUSTER '{cluster}' ADD COLUMN content.response_code Float64 DEFAULT fields_number.value[indexOf(fields_number.key, 'content.response_code')]
 ```

--- a/cluster/clickhouse/clickhouse.yaml
+++ b/cluster/clickhouse/clickhouse.yaml
@@ -18,6 +18,8 @@ spec:
       - name: sharded
         layout:
           shardsCount: 2
+          replicasCount: 1
+
     users:
       admin/password: admin
       admin/networks/ip: "::/0"
@@ -56,4 +58,4 @@ spec:
             - name: dockerhub-registry
           containers:
             - name: clickhouse
-              image: yandex/clickhouse-server:21.11.4.14
+              image: yandex/clickhouse-server:21.12.3.32

--- a/cluster/clickhouse/zookeeper-pdb.yaml
+++ b/cluster/clickhouse/zookeeper-pdb.yaml
@@ -1,0 +1,13 @@
+---
+# Setup max number of unavailable pods in StatefulSet
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: zookeeper
+  namespace: clickhouse
+spec:
+  selector:
+    matchLabels:
+      app: zookeeper
+      what: node
+  maxUnavailable: 1

--- a/cluster/clickhouse/zookeeper-sts.yaml
+++ b/cluster/clickhouse/zookeeper-sts.yaml
@@ -1,0 +1,155 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: zookeeper
+  namespace: clickhouse
+spec:
+  selector:
+    matchLabels:
+      app: zookeeper
+      what: node
+  serviceName: zookeepers
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: zookeeper
+        what: node
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                      - zookeeper
+              topologyKey: "kubernetes.io/hostname"
+      imagePullSecrets:
+        - name: dockerhub-registry
+      containers:
+        - name: kubernetes-zookeeper
+          imagePullPolicy: IfNotPresent
+          image: "docker.io/zookeeper:3.6.2"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "500m"
+            limits:
+              memory: "2Gi"
+              cpu: "2000m"
+          ports:
+            - containerPort: 2181
+              name: client
+            - containerPort: 2888
+              name: server
+            - containerPort: 3888
+              name: leader-election
+            - containerPort: 7000
+              name: prometheus
+          # See those links for proper startup settings:
+          # https://github.com/kow3ns/kubernetes-zookeeper/blob/master/docker/scripts/start-zookeeper
+          # https://clickhouse.yandex/docs/en/operations/tips/#zookeeper
+          # https://github.com/ClickHouse/ClickHouse/issues/11781
+          command:
+            - bash
+            - -x
+            - -c
+            - |
+              SERVERS=3 &&
+              HOST=`hostname -s` &&
+              DOMAIN=`hostname -d` &&
+              CLIENT_PORT=2181 &&
+              SERVER_PORT=2888 &&
+              ELECTION_PORT=3888 &&
+              PROMETHEUS_PORT=7000 &&
+              ZOO_DATA_DIR=/var/lib/zookeeper/data &&
+              ZOO_DATA_LOG_DIR=/var/lib/zookeeper/datalog &&
+              {
+                echo "clientPort=${CLIENT_PORT}"
+                echo 'tickTime=2000'
+                echo 'initLimit=300'
+                echo 'syncLimit=10'
+                echo 'maxClientCnxns=2000'
+                echo 'maxSessionTimeout=60000000'
+                echo "dataDir=${ZOO_DATA_DIR}"
+                echo "dataLogDir=${ZOO_DATA_LOG_DIR}"
+                echo 'autopurge.snapRetainCount=10'
+                echo 'autopurge.purgeInterval=1'
+                echo 'preAllocSize=131072'
+                echo 'snapCount=3000000'
+                echo 'leaderServes=yes'
+                echo 'standaloneEnabled=true'
+                echo '4lw.commands.whitelist=stat, ruok, conf, isro'
+                echo 'metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider'
+                echo "metricsProvider.httpPort=${PROMETHEUS_PORT}"
+                echo "quorumListenOnAllIPs=true"
+              } > /conf/zoo.cfg &&
+              {
+                echo "zookeeper.root.logger=CONSOLE"
+                echo "zookeeper.console.threshold=INFO"
+                echo "log4j.rootLogger=\${zookeeper.root.logger}"
+                echo "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender"
+                echo "log4j.appender.CONSOLE.Threshold=\${zookeeper.console.threshold}"
+                echo "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout"
+                echo "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n"
+              } > /conf/log4j.properties &&
+              echo 'JVMFLAGS="-Xms128M -Xmx4G -XX:+UseG1GC -XX:+CMSParallelRemarkEnabled"' > /conf/java.env &&
+              if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
+                  NAME=${BASH_REMATCH[1]}
+                  ORD=${BASH_REMATCH[2]}
+              else
+                  echo "Failed to parse name and ordinal of Pod"
+                  exit 1
+              fi &&
+              mkdir -p ${ZOO_DATA_DIR} &&
+              mkdir -p ${ZOO_DATA_LOG_DIR} &&
+              export MY_ID=$((ORD+1)) &&
+              echo $MY_ID > $ZOO_DATA_DIR/myid &&
+              if [[ $SERVERS -gt 1 ]]; then
+                for (( i=1; i<=$SERVERS; i++ )); do
+                    echo "server.$i=$NAME-$((i-1)).$DOMAIN:$SERVER_PORT:$ELECTION_PORT" >> /conf/zoo.cfg;
+                done
+              fi &&
+              chown -Rv zookeeper "$ZOO_DATA_DIR" "$ZOO_DATA_LOG_DIR" "$ZOO_LOG_DIR" "$ZOO_CONF_DIR" &&
+              zkServer.sh start-foreground
+          readinessProbe:
+            exec:
+              command:
+                - bash
+                - -c
+                - "OK=$(echo ruok | nc 127.0.0.1 2181); if [[ \"$OK\" == \"imok\" ]]; then exit 0; else exit 1; fi"
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - bash
+                - -c
+                - "OK=$(echo ruok | nc 127.0.0.1 2181); if [[ \"$OK\" == \"imok\" ]]; then exit 0; else exit 1; fi"
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: datadir-volume
+              mountPath: /var/lib/zookeeper
+      # Run as a non-privileged user
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir-volume
+      spec:
+        storageClassName: managed-premium
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Gi

--- a/cluster/clickhouse/zookeeper-zookeeper-svc.yaml
+++ b/cluster/clickhouse/zookeeper-zookeeper-svc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper
+  namespace: clickhouse
+  labels:
+    app: zookeeper
+spec:
+  ports:
+    - port: 2181
+      name: client
+    - port: 7000
+      name: prometheus
+  selector:
+    app: zookeeper
+    what: node

--- a/cluster/clickhouse/zookeeper-zookeepers-svc.yaml
+++ b/cluster/clickhouse/zookeeper-zookeepers-svc.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeepers
+  namespace: clickhouse
+  labels:
+    app: zookeeper
+spec:
+  ports:
+    - port: 2888
+      name: server
+    - port: 3888
+      name: leader-election
+  clusterIP: None
+  selector:
+    app: zookeeper
+    what: node

--- a/schema.sql
+++ b/schema.sql
@@ -1,19 +1,19 @@
 CREATE DATABASE IF NOT EXISTS logs ENGINE=Atomic;
 
-CREATE TABLE IF NOT EXISTS logs.logs_local(
-  timestamp DateTime64(3) CODEC(Delta, ZSTD(1)),
-  cluster LowCardinality(String) CODEC(ZSTD(1)),
-  namespace LowCardinality(String) CODEC(ZSTD(1)),
-  app String CODEC(ZSTD(1)),
-  pod_name String CODEC(ZSTD(1)),
-  container_name String CODEC(ZSTD(1)),
-  host String CODEC(ZSTD(1)),
-  fields_string Nested(key String, value String) CODEC(ZSTD(1)),
-  fields_number Nested(key String, value Float64) CODEC(ZSTD(1)),
-  log String CODEC(ZSTD(1))
-) ENGINE = MergeTree()
+CREATE TABLE IF NOT EXISTS logs.logs_local ON CLUSTER '{cluster}' (
+  timestamp DateTime64(3) CODEC (Delta, ZSTD(1)),
+  cluster LowCardinality(String) CODEC (ZSTD(1)),
+  namespace LowCardinality(String) CODEC (ZSTD(1)),
+  app String CODEC (ZSTD(1)),
+  pod_name String CODEC (ZSTD(1)),
+  container_name String CODEC (ZSTD(1)),
+  host String CODEC (ZSTD(1)),
+  fields_string Nested(key String, value String) CODEC (ZSTD(1)),
+  fields_number Nested(key String, value Float64) CODEC (ZSTD(1)),
+  log String CODEC (ZSTD(1))
+) ENGINE = ReplicatedMergeTree()
   TTL toDateTime(timestamp) + INTERVAL 30 DAY DELETE
   PARTITION BY toDate(timestamp)
   ORDER BY (cluster, namespace, app, pod_name, container_name, host, -toUnixTimestamp(timestamp));
 
-CREATE TABLE IF NOT EXISTS logs.logs AS logs.logs_local ENGINE = Distributed('{cluster}', logs, logs_local, cityHash64(cluster, namespace, app, pod_name, container_name, host));
+CREATE TABLE IF NOT EXISTS logs.logs ON CLUSTER '{cluster}' AS logs.logs_local ENGINE = Distributed('{cluster}', logs, logs_local, rand());


### PR DESCRIPTION
This commit updates the used SQL schema. We are now using
the ReplicatedMergeTree engine instead of MergeTree. This allows us to
replicate the ingested logs via Zookeeper and we only have to initialize
one node instead of all ClickHouse nodes.