### PR TITLE
New schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,31 +18,51 @@ The SQL schema for ClickHouse must be created on each ClickHouse node and looks 
 ```sql
 CREATE DATABASE IF NOT EXISTS logs ENGINE=Atomic;
 
-CREATE TABLE IF NOT EXISTS logs.logs_local ON CLUSTER '{cluster}' (
-  timestamp DateTime64(3) CODEC (Delta, ZSTD(1)),
-  cluster LowCardinality(String) CODEC (ZSTD(1)),
-  namespace LowCardinality(String) CODEC (ZSTD(1)),
-  app String CODEC (ZSTD(1)),
-  pod_name String CODEC (ZSTD(1)),
-  container_name String CODEC (ZSTD(1)),
-  host String CODEC (ZSTD(1)),
-  fields_string Nested(key String, value String) CODEC (ZSTD(1)),
-  fields_number Nested(key String, value Float64) CODEC (ZSTD(1)),
-  log String CODEC (ZSTD(1))
-) ENGINE = ReplicatedMergeTree()
-  TTL toDateTime(timestamp) + INTERVAL 30 DAY DELETE
-  PARTITION BY toDate(timestamp)
-  ORDER BY (cluster, namespace, app, pod_name, container_name, host, -toUnixTimestamp(timestamp));
+CREATE TABLE IF NOT EXISTS logs.logs_local ON CLUSTER `{cluster}`
+(
+    `timestamp` DateTime64(3) CODEC(Delta, LZ4),
+    `cluster` LowCardinality(String),
+    `namespace` LowCardinality(String),
+    `app` LowCardinality(String),
+    `pod_name` LowCardinality(String),
+    `container_name` LowCardinality(String),
+    `host` LowCardinality(String),
+    `fields_string.key` Array(LowCardinality(String)),
+    `fields_string.value` Array(String) CODEC(ZSTD(1)),
+    `fields_number.key` Array(LowCardinality(String)),
+    `fields_number.value` Array(Float64),
+    `log` String CODEC(ZSTD(1))
+)
+ENGINE = ReplicatedMergeTree
+PARTITION BY toDate(timestamp)
+ORDER BY (cluster, namespace, app, pod_name, container_name, host, timestamp)
+TTL toDateTime(timestamp) + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS logs.logs ON CLUSTER '{cluster}' AS logs.logs_local ENGINE = Distributed('{cluster}', logs, logs_local, rand());
 ```
 
-To speedup queries for the most frequently queried fields we can materializing them to dedicated columns:
+To speedup queries for the most frequently queried fields we can create dedicated columns for specific fiels:
 
 ```sql
-ALTER TABLE logs.logs_local ON CLUSTER '{cluster}' ADD COLUMN content.level String DEFAULT fields_string.value[indexOf(fields_string.key, 'content.level')]
-ALTER TABLE logs.logs ON CLUSTER '{cluster}' ADD COLUMN content.level String DEFAULT fields_string.value[indexOf(fields_string.key, 'content.level')]
+ALTER TABLE logs.logs_local ON CLUSTER '{cluster}' ADD COLUMN content_level String DEFAULT fields_string.value[indexOf(fields_string.key, 'content.level')]
+ALTER TABLE logs.logs ON CLUSTER '{cluster}' ADD COLUMN content_level String DEFAULT fields_string.value[indexOf(fields_string.key, 'content.level')]
 
-ALTER TABLE logs.logs_local ON CLUSTER '{cluster}' ADD COLUMN content.response_code Float64 DEFAULT fields_number.value[indexOf(fields_number.key, 'content.response_code')]
-ALTER TABLE logs.logs ON CLUSTER '{cluster}' ADD COLUMN content.response_code Float64 DEFAULT fields_number.value[indexOf(fields_number.key, 'content.response_code')]
+ALTER TABLE logs.logs_local ON CLUSTER '{cluster}' ADD COLUMN content_response_code Float64 DEFAULT fields_number.value[indexOf(fields_number.key, 'content.response_code')]
+ALTER TABLE logs.logs ON CLUSTER '{cluster}' ADD COLUMN content_response_code Float64 DEFAULT fields_number.value[indexOf(fields_number.key, 'content.response_code')]
+```
+
+But those columns will be materialized only for new data and after merges.
+In order to materialize those columns for old data:
+you can use `ALTER TABLE MATERIALIZE COLUMN` for ClickHouse version > 21.10. 
+
+```sql
+ALTER TABLE logs.logs_local ON CLUSTER '{cluster}' MATERIALIZE COLUMN content_level;
+ALTER TABLE logs.logs_local ON CLUSTER '{cluster}' MATERIALIZE COLUMN content_response_code;
+```
+
+Or for older ClickHouse versions, `ALTER TABLE UPDATE`.
+
+```sql
+ALTER TABLE logs.logs_local ON CLUSTER '{cluster}' UPDATE content_level = content_level WHERE 1;
+ALTER TABLE logs.logs_local ON CLUSTER '{cluster}' UPDATE content_response_code = content_response_code WHERE 1;
 ```

--- a/schema.sql
+++ b/schema.sql
@@ -15,5 +15,25 @@ CREATE TABLE IF NOT EXISTS logs.logs_local ON CLUSTER '{cluster}' (
   TTL toDateTime(timestamp) + INTERVAL 30 DAY DELETE
   PARTITION BY toDate(timestamp)
   ORDER BY (cluster, namespace, app, pod_name, container_name, host, -toUnixTimestamp(timestamp));
+  
+CREATE TABLE IF NOT EXISTS logs.logs_local ON CLUSTER `{cluster}`
+(
+    `timestamp` DateTime64(3) CODEC(Delta, LZ4),
+    `cluster` LowCardinality(String),
+    `namespace` LowCardinality(String),
+    `app` LowCardinality(String),
+    `pod_name` LowCardinality(String),
+    `container_name` LowCardinality(String),
+    `host` LowCardinality(String),
+    `fields_string.key` Array(LowCardinality(String)),
+    `fields_string.value` Array(String) CODEC(ZSTD(1)),
+    `fields_number.key` Array(LowCardinality(String)),
+    `fields_number.value` Array(Float64),
+    `log` String CODEC(ZSTD(1))
+)
+ENGINE = ReplicatedMergeTree
+PARTITION BY toDate(timestamp)
+ORDER BY (cluster, namespace, app, pod_name, container_name, host, timestamp)
+TTL toDateTime(timestamp) + INTERVAL 30 DAY
 
 CREATE TABLE IF NOT EXISTS logs.logs ON CLUSTER '{cluster}' AS logs.logs_local ENGINE = Distributed('{cluster}', logs, logs_local, rand());

--- a/schema.sql
+++ b/schema.sql
@@ -1,21 +1,5 @@
 CREATE DATABASE IF NOT EXISTS logs ENGINE=Atomic;
 
-CREATE TABLE IF NOT EXISTS logs.logs_local ON CLUSTER '{cluster}' (
-  timestamp DateTime64(3) CODEC (Delta, ZSTD(1)),
-  cluster LowCardinality(String) CODEC (ZSTD(1)),
-  namespace LowCardinality(String) CODEC (ZSTD(1)),
-  app String CODEC (ZSTD(1)),
-  pod_name String CODEC (ZSTD(1)),
-  container_name String CODEC (ZSTD(1)),
-  host String CODEC (ZSTD(1)),
-  fields_string Nested(key String, value String) CODEC (ZSTD(1)),
-  fields_number Nested(key String, value Float64) CODEC (ZSTD(1)),
-  log String CODEC (ZSTD(1))
-) ENGINE = ReplicatedMergeTree()
-  TTL toDateTime(timestamp) + INTERVAL 30 DAY DELETE
-  PARTITION BY toDate(timestamp)
-  ORDER BY (cluster, namespace, app, pod_name, container_name, host, -toUnixTimestamp(timestamp));
-  
 CREATE TABLE IF NOT EXISTS logs.logs_local ON CLUSTER `{cluster}`
 (
     `timestamp` DateTime64(3) CODEC(Delta, LZ4),
@@ -34,6 +18,6 @@ CREATE TABLE IF NOT EXISTS logs.logs_local ON CLUSTER `{cluster}`
 ENGINE = ReplicatedMergeTree
 PARTITION BY toDate(timestamp)
 ORDER BY (cluster, namespace, app, pod_name, container_name, host, timestamp)
-TTL toDateTime(timestamp) + INTERVAL 30 DAY
+TTL toDateTime(timestamp) + INTERVAL 30 DAY;
 
 CREATE TABLE IF NOT EXISTS logs.logs ON CLUSTER '{cluster}' AS logs.logs_local ENGINE = Distributed('{cluster}', logs, logs_local, rand());


### PR DESCRIPTION
Important and doesn't require to recreate table (can be done on existing table): 

String -> LowCardinality(String)
CODEC(ZSTD(1)) -> no codec or CODEC(LZ4)

Not really important, but makes schema a bit cleaner:

-toUnixTimestamp(timestamp) -> timestamp

Probably, it can make sense to put `host` column before `pod_name` in `ORDER BY`, but it's needs to be tested.

BTW, it's not recommended to use `.` in non-array column.
Because dot reserved for Nested data type.

#### Using map instead of key-value arrays
	
```
CREATE TABLE IF NOT EXISTS logs.logs_local ON CLUSTER `{cluster}`
(
    `timestamp` DateTime64(3) CODEC(Delta, LZ4),
    `cluster` LowCardinality(String),
    `namespace` LowCardinality(String),
    `app` LowCardinality(String),
    `pod_name` LowCardinality(String),
    `container_name` LowCardinality(String),
    `host` LowCardinality(String),
    `fields_string` Map(LowCardinality(String), String),
    `fields_number` Map(LowCardinality(String), Float64),
    `fields_string.key` Array(LowCardinality(String)) ALIAS mapKeys(fields_string),
    `fields_string.value` Array(String) ALIAS mapValues(fields_string),
    `fields_number.key` Array(LowCardinality(String)) ALIAS mapKeys(fields_number),
    `fields_number.value` Array(Float64) ALIAS mapValues(fields_number),
    `log` String CODEC(ZSTD(1))
)
ENGINE = ReplicatedMergeTree
PARTITION BY toDate(timestamp)
ORDER BY (cluster, namespace, app, pod_name, container_name, host, timestamp)
TTL toDateTime(timestamp) + INTERVAL 30 DAY;
```

It will make queries cleanier and a bit faster, eg:

```sql
SELECT fields_string.value[indexOf(fields_string.key, 'content.level')] FROM logs.logs;

SELECT fields_string['content.level'] FROM logs.logs;
```

But returning maps is not supported yet in clickhouse-go afaik.
https://github.com/ClickHouse/clickhouse-go/issues/380

#### Projection optimization:

Starting from ClickHouse 21.8, we can add projections to speedup some queries:

```sql
ALTER TABLE logs.logs_local ON CLUSTER '{cluster}' ADD PROJECTION buckets (SELECT cluster, namespace, app, pod_name, container_name, toStartOfInterval(timestamp, INTERVAL 30 second) AS interval_data, count() GROUP BY cluster, namespace, app, pod_name, container_name);

ALTER TABLE logs.logs_local ON CLUSTER '{cluster}' MATERIALIZE PROJECTION buckets;
```

Enable setting for using projections in queries:

```
allow_experimental_projection_optimization = 1
```

But you need to write queries in following way (use `interval_data` instead of `timestamp`):

```sql
SELECT
    toStartOfInterval(timestamp, toIntervalSecond(30)) AS interval_data,
    count(*) AS count_data
FROM logs.logs
WHERE (interval_data >= FROM_UNIXTIME(1641923841)) AND (interval_data <= FROM_UNIXTIME(1641924741)) AND (namespace = 'kobs') AND (app = 'kobs') AND (container_name = 'kobs')
GROUP BY interval_data
ORDER BY interval_data ASC WITH FILL FROM toStartOfInterval(FROM_UNIXTIME(1641923841), toIntervalSecond(30)) TO toStartOfInterval(FROM_UNIXTIME(1641924741), toIntervalSecond(30)) STEP 30
```

#### Constraint optimization:

Starting from ClickHouse 21.12, it's possible to teach ClickHouse rewrite `fields_string.value[indexOf(fields_string.key, 'content.level')]` to `content_level` column by adding constraints.

```sql
ALTER TABLE logs.logs_local ON CLUSTER '{cluster}' ADD CONSTRAINT content_level_cnst ASSUME content_level = fields_string.value[indexOf(fields_string.key, 'content.level')];
ALTER TABLE logs.logs_local ON CLUSTER '{cluster}' ADD CONSTRAINT content_response_code_cnst ASSUME content_response_code = fields_number.value[indexOf(fields_number.key, 'content.response_code')];
```

In order to allow it in queries, you need to set those settings for user:

```
optimize_using_constraints = 1
optimize_substitute_columns = 1
convert_query_to_cnf = 1
optimize_append_index = 1
```

But there is one issue about them:
https://github.com/ClickHouse/ClickHouse/issues/33544

```sql
SELECT fields_string.value[indexOf(fields_string.key, 'content.level')] FROM logs.logs; -- will not be optimized

SELECT fields_string.value[indexOf(fields_string.key, 'content.level')] FROM logs.logs WHERE fields_string.value[indexOf(fields_string.key, 'content.level')] = 'value'; -- will be optimized
```

But what if we don't want to actually filter by our column?
There is way to hack ClickHouse into using constraints by doing this:

```sql
SELECT fields_string.value[indexOf(fields_string.key, 'content.level')] FROM logs.logs WHERE NOT ignore(fields_string.value[indexOf(fields_string.key, 'content.level')]); -- will be optimized
```