### PR TITLE
Fix example manifests

### DIFF
--- a/cluster/clickhouse/clickhouse.yaml
+++ b/cluster/clickhouse/clickhouse.yaml
@@ -14,6 +14,10 @@ spec:
       podTemplate: default
 
   configuration:
+    zookeeper:
+      nodes:
+        - host: zookeeper.clickhouse.svc.cluster.local
+
     clusters:
       - name: sharded
         layout:

--- a/cluster/clickhouse/zookeeper-sts.yaml
+++ b/cluster/clickhouse/zookeeper-sts.yaml
@@ -19,19 +19,7 @@ spec:
       labels:
         app: zookeeper
         what: node
-      annotations:
-        sidecar.istio.io/inject: "false"
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: "app"
-                    operator: In
-                    values:
-                      - zookeeper
-              topologyKey: "kubernetes.io/hostname"
       imagePullSecrets:
         - name: dockerhub-registry
       containers:
@@ -147,9 +135,8 @@ spec:
     - metadata:
         name: datadir-volume
       spec:
-        storageClassName: managed-premium
         accessModes:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 100Gi
+            storage: 5Gi

--- a/cluster/fluent-bit/plugin/fluent-bit-cm.yaml
+++ b/cluster/fluent-bit/plugin/fluent-bit-cm.yaml
@@ -21,17 +21,20 @@ data:
     [INPUT]
         Name              tail
         Path              /var/log/containers/*.log
-        Parser            docker
+        Multiline.Parser  docker, cri
         Tag               kube.*
         Refresh_Interval  5
-        Mem_Buf_Limit     20MB
-        Skip_Long_Lines   On
+        Buffer_Chunk_Size 256k
+        Buffer_Max_Size   256k
+        Mem_Buf_Limit     128MB
+        Skip_Long_Lines   Off
         DB                /tail-db/tail-containers-state.db
         DB.Sync           Normal
 
     [FILTER]
         Name                kubernetes
         Match               kube.*
+        Buffer_Size         256k
         Kube_Tag_Prefix     kube.var.log.containers.
         Kube_URL            https://kubernetes.default.svc:443
         Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
@@ -59,7 +62,7 @@ data:
         Wait_For_Async_Insert true
         Batch_Size            1000
         Flush_Interval        10s
-        Log_Format            plain
+        Log_Format            json
         Log_Level             debug
 
   parsers.conf: |


### PR DESCRIPTION
The example manifests were not working correctly, because the Zookeeper
Pods were not create in the kind cluster because of the affinity rules.
In the ClickHouse CR the Zookeeper configuration was missing and the
Fluent Bit configuration used "Parse" instead of "Multiline.Parse" so
that the parsing didn't work correctly.