### PR TITLE
Rename repository in go.mod file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 ## Unreleased
 
+- [#24](https://github.com/kobsio/klogs/pull/24): Rename repository in `go.mod` file to `github.com/kobsio/klogs`.
+
 ## [v0.7.0](https://github.com/kobsio/klogs/releases/tag/v0.7.0) (2022-01-14)
 
 - [#15](https://github.com/kobsio/klogs/pull/15): Update the used SQL schema to use `ReplicatedMergeTree` instead of `MergeTree`.

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kobsio/fluent-bit-clickhouse/pkg/clickhouse"
-	"github.com/kobsio/fluent-bit-clickhouse/pkg/kafka"
-	"github.com/kobsio/fluent-bit-clickhouse/pkg/log"
-	"github.com/kobsio/fluent-bit-clickhouse/pkg/version"
+	"github.com/kobsio/klogs/pkg/clickhouse"
+	"github.com/kobsio/klogs/pkg/kafka"
+	"github.com/kobsio/klogs/pkg/log"
+	"github.com/kobsio/klogs/pkg/version"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	flag "github.com/spf13/pflag"
@@ -214,7 +214,7 @@ func main() {
 	// The short form of the version information is also printed in two lines, when the version option is set to
 	// "false".
 	if showVersion {
-		v, err := version.Print("kobs")
+		v, err := version.Print("klogs-ingester")
 		if err != nil {
 			log.Fatal(nil, "Failed to print version information", zap.Error(err))
 		}

--- a/cmd/plugin/main.go
+++ b/cmd/plugin/main.go
@@ -12,10 +12,10 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/kobsio/fluent-bit-clickhouse/pkg/clickhouse"
-	flatten "github.com/kobsio/fluent-bit-clickhouse/pkg/flatten/interface"
-	"github.com/kobsio/fluent-bit-clickhouse/pkg/log"
-	"github.com/kobsio/fluent-bit-clickhouse/pkg/version"
+	"github.com/kobsio/klogs/pkg/clickhouse"
+	flatten "github.com/kobsio/klogs/pkg/flatten/interface"
+	"github.com/kobsio/klogs/pkg/log"
+	"github.com/kobsio/klogs/pkg/version"
 
 	"github.com/fluent/fluent-bit-go/output"
 	"go.uber.org/zap"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kobsio/fluent-bit-clickhouse
+module github.com/kobsio/klogs
 
 go 1.17
 

--- a/pkg/clickhouse/clickhouse.go
+++ b/pkg/clickhouse/clickhouse.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kobsio/fluent-bit-clickhouse/pkg/log"
+	"github.com/kobsio/klogs/pkg/log"
 
 	"github.com/ClickHouse/clickhouse-go"
 	"go.uber.org/zap"

--- a/pkg/kafka/consumer.go
+++ b/pkg/kafka/consumer.go
@@ -7,9 +7,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/kobsio/fluent-bit-clickhouse/pkg/clickhouse"
-	flatten "github.com/kobsio/fluent-bit-clickhouse/pkg/flatten/string"
-	"github.com/kobsio/fluent-bit-clickhouse/pkg/log"
+	"github.com/kobsio/klogs/pkg/clickhouse"
+	flatten "github.com/kobsio/klogs/pkg/flatten/string"
+	"github.com/kobsio/klogs/pkg/log"
 
 	"github.com/Shopify/sarama"
 	"github.com/prometheus/client_golang/prometheus"

--- a/pkg/kafka/kafka.go
+++ b/pkg/kafka/kafka.go
@@ -9,8 +9,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/kobsio/fluent-bit-clickhouse/pkg/clickhouse"
-	"github.com/kobsio/fluent-bit-clickhouse/pkg/log"
+	"github.com/kobsio/klogs/pkg/clickhouse"
+	"github.com/kobsio/klogs/pkg/log"
 
 	"github.com/Shopify/sarama"
 	"go.uber.org/zap"


### PR DESCRIPTION
During the renaming of the repository from "fluent-bit-clickhouse" to
"klogs" we forgot to adjust the name in the "go.mod" file. This is done
within this PR so that we are now using "github.com/kobsio/klogs" in the
"go.mod" file.