### PR TITLE
Use official Filebeat image as base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 - [#28](https://github.com/kobsio/klogs/pull/28): Add Filebeat as alternative to Fluent Bit.
 - [#29](https://github.com/kobsio/klogs/pull/29): Update Fluent Bit to version 1.9.1.
+- [#30](https://github.com/kobsio/klogs/pull/30): Use official Filebeat image as base image.
 
 ## [v0.8.0](https://github.com/kobsio/klogs/releases/tag/v0.8.0) (2022-03-09)
 

--- a/cmd/filebeat/Dockerfile
+++ b/cmd/filebeat/Dockerfile
@@ -6,10 +6,5 @@ RUN go mod download
 COPY . .
 RUN export CGO_ENABLED=0 && make build-filebeat
 
-FROM alpine:3.14.2
-RUN apk update && apk add --no-cache ca-certificates
-RUN mkdir /filebeat
-COPY --from=build /filebeat/filebeat /filebeat
-WORKDIR /filebeat
-USER nobody
-ENTRYPOINT  [ "/filebeat/filebeat" ]
+FROM docker.elastic.co/beats/filebeat:7.17.1
+COPY --from=build /filebeat/filebeat /usr/share/filebeat


### PR DESCRIPTION
We used Alpine as base image for Filebeat, but because of this we see
some errors that several modules are missing. To fix these errors we are
now using the official Filebeat image as base image, which already comes
with some modules.