### PR TITLE
Omit "nil" values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 ## Unreleased
 
+- [#31](https://github.com/kobsio/klogs/pull/31): Omit `nil` values.
+
 ## [v0.9.0](https://github.com/kobsio/klogs/releases/tag/v0.9.0) (2022-03-31)
 
 - [#28](https://github.com/kobsio/klogs/pull/28): Add Filebeat as alternative to Fluent Bit.

--- a/cmd/plugin/main.go
+++ b/cmd/plugin/main.go
@@ -194,8 +194,11 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int 
 			var stringValue string
 			var numberValue float64
 			var isNumber bool
+			var isNil bool
 
 			switch t := v.(type) {
+			case nil:
+				isNil = true
 			case string:
 				stringValue = t
 			case []byte:
@@ -237,40 +240,42 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int 
 				stringValue = fmt.Sprintf("%v", v)
 			}
 
-			switch k {
-			case "cluster":
-				row.Cluster = stringValue
-			case "kubernetes.namespace_name":
-				row.Namespace = stringValue
-			case "kubernetes.labels.k8s-app":
-				row.App = stringValue
-			case "kubernetes.labels.app":
-				row.App = stringValue
-			case "kubernetes.pod_name":
-				row.Pod = stringValue
-			case "kubernetes.container_name":
-				row.Container = stringValue
-			case "kubernetes.host":
-				row.Host = stringValue
-			case "log":
-				row.Log = stringValue
-			default:
-				if isNumber {
-					row.FieldsNumber.Key = append(row.FieldsNumber.Key, k)
-					row.FieldsNumber.Value = append(row.FieldsNumber.Value, numberValue)
-				} else {
-					if contains(k, forceNumberFields) {
-						parsedNumber, err := strconv.ParseFloat(stringValue, 64)
-						if err == nil {
-							row.FieldsNumber.Key = append(row.FieldsNumber.Key, k)
-							row.FieldsNumber.Value = append(row.FieldsNumber.Value, parsedNumber)
+			if !isNil {
+				switch k {
+				case "cluster":
+					row.Cluster = stringValue
+				case "kubernetes.namespace_name":
+					row.Namespace = stringValue
+				case "kubernetes.labels.k8s-app":
+					row.App = stringValue
+				case "kubernetes.labels.app":
+					row.App = stringValue
+				case "kubernetes.pod_name":
+					row.Pod = stringValue
+				case "kubernetes.container_name":
+					row.Container = stringValue
+				case "kubernetes.host":
+					row.Host = stringValue
+				case "log":
+					row.Log = stringValue
+				default:
+					if isNumber {
+						row.FieldsNumber.Key = append(row.FieldsNumber.Key, k)
+						row.FieldsNumber.Value = append(row.FieldsNumber.Value, numberValue)
+					} else {
+						if contains(k, forceNumberFields) {
+							parsedNumber, err := strconv.ParseFloat(stringValue, 64)
+							if err == nil {
+								row.FieldsNumber.Key = append(row.FieldsNumber.Key, k)
+								row.FieldsNumber.Value = append(row.FieldsNumber.Value, parsedNumber)
+							} else {
+								row.FieldsString.Key = append(row.FieldsString.Key, k)
+								row.FieldsString.Value = append(row.FieldsString.Value, stringValue)
+							}
 						} else {
 							row.FieldsString.Key = append(row.FieldsString.Key, k)
 							row.FieldsString.Value = append(row.FieldsString.Value, stringValue)
 						}
-					} else {
-						row.FieldsString.Key = append(row.FieldsString.Key, k)
-						row.FieldsString.Value = append(row.FieldsString.Value, stringValue)
 					}
 				}
 			}


### PR DESCRIPTION
When a key in a log line has the value "null", we do not append this
key/value to the fields array, so that we can use the "_exists_"
operation to filter for fields where the value is nil.