### PR TITLE
:warning: Change delimiter to underscore

### DIFF
--- a/pkg/flatten/interface/flatten.go
+++ b/pkg/flatten/interface/flatten.go
@@ -57,7 +57,7 @@ func enkey(top bool, prefix, subkey string) string {
 	if top {
 		key += subkey
 	} else {
-		key += "." + subkey
+		key += "_" + subkey
 	}
 
 	return key

--- a/pkg/flatten/string/flatten.go
+++ b/pkg/flatten/string/flatten.go
@@ -57,7 +57,7 @@ func enkey(top bool, prefix, subkey string) string {
 	if top {
 		key += subkey
 	} else {
-		key += "." + subkey
+		key += "_" + subkey
 	}
 
 	return key


### PR DESCRIPTION
We are now using an underscore ("_") instead of a point (".") as delimiter for the flatten JSON.

This is needed, so that we can simplify the queries for materialized columns where we also changed the column names to use an underscore instead of a point in the past.