### PR TITLE
Add new force underscores setting

### DIFF
--- a/cmd/ingester/README.md
+++ b/cmd/ingester/README.md
@@ -23,6 +23,7 @@ An example Deployment for the ClickHouse ingester can be found in the [ingester.
 | `--clickhouse.batch-size` | `CLICKHOUSE_BATCH_SIZE` | The size for how many log lines should be buffered, before they are written to ClickHouse. | `100000` |
 | `--clickhouse.flush-interval` | `CLICKHOUSE_FLUSH_INTERVAL` | The maximum amount of time to wait, before logs are written to ClickHouse. | `60s` |
 | `--clickhouse.force-number-fields` | `CLICKHOUSE_FORCE_NUMBER_FIELDS` | A list of fields which should be parsed as number. | `[]` |
+| `--clickhouse.force-underscores` | `CLICKHOUSE_FORCE_UNDERSCORES` | Replace all `.` with `_` in keys. | `false` |
 | `--kafka.brokers` | `KAFKA_BROKERS` | Kafka bootstrap brokers to connect to, as a comma separated list | |
 | `--kafka.group` | `KAFKA_GROUP` | Kafka consumer group definition | `kafka-clickhouse` |
 | `--kafka.version` | `KAFKA_VERSION` | Kafka cluster version | `2.1.1` |

--- a/cmd/plugin/README.md
+++ b/cmd/plugin/README.md
@@ -23,6 +23,7 @@ An example configuration file can be found in the [fluent-bit-cm.yaml](../../clu
 | `Batch_Size` | The size for how many log lines should be buffered, before they are written to ClickHouse. | `10000` |
 | `Flush_Interval` | The maximum amount of time to wait, before logs are written to ClickHouse. | `60s` |
 | `Force_Number_Fields` | A list of fields which should be parsed as number. | `60s` |
+| `Force_Underscores` | Replace all `.` with `_` in keys. | `false` |
 | `Log_Format` | The log format for the Fluent Bit ClickHouse plugin. Must be `console` or `json`. | `console` |
 | `Log_Level` | The log level for the Fluent Bit ClickHouse plugin. Must be `debug`, `info`, `warn`, `error`, `fatal` or `panic`. | `info` |
 

--- a/pkg/kafka/kafka.go
+++ b/pkg/kafka/kafka.go
@@ -18,7 +18,7 @@ import (
 
 // Run creates a new client for the given Kafka configuration and listens for incomming messages. These messages are
 // then written to ClickHouse when the batch size or flush interval is over.
-func Run(kafkaBrokers, kafkaGroup, kafkaVersion, kafkaTopics, kafkaTimestampKey string, clickhouseBatchSize int64, clickhouseFlushInterval time.Duration, clickhouseForceNumberFields []string, clickhouseClient *clickhouse.Client) {
+func Run(kafkaBrokers, kafkaGroup, kafkaVersion, kafkaTopics, kafkaTimestampKey string, clickhouseBatchSize int64, clickhouseFlushInterval time.Duration, clickhouseForceNumberFields []string, clickhouseForceUnderscores bool, clickhouseClient *clickhouse.Client) {
 	version, err := sarama.ParseKafkaVersion(kafkaVersion)
 	if err != nil {
 		log.Fatal(nil, "Error parsing Kafka version", zap.Error(err))
@@ -37,6 +37,7 @@ func Run(kafkaBrokers, kafkaGroup, kafkaVersion, kafkaTopics, kafkaTimestampKey 
 		clickhouseBatchSize:         clickhouseBatchSize,
 		clickhouseFlushInterval:     clickhouseFlushInterval,
 		clickhouseForceNumberFields: clickhouseForceNumberFields,
+		clickhouseForceUnderscores:  clickhouseForceUnderscores,
 		clickhouseClient:            clickhouseClient,
 	}
 


### PR DESCRIPTION
It is now possible to set the "Force_Underscores" setting, to replace all dots with underscores in the JSON keys of a log line.