### PR TITLE
Change default values for ClickHouse connections

### DIFF
--- a/cmd/ingester/README.md
+++ b/cmd/ingester/README.md
@@ -16,8 +16,8 @@ An example Deployment for the ClickHouse ingester can be found in the [ingester.
 | `--clickhouse.password` | `CLICKHOUSE_PASSWORD` | ClickHouse password for the connection. | |
 | `--clickhouse.dial-timeout` | `CLICKHOUSE_DIAL_TIMEOUT` | ClickHouse dial timeout. | `10s` |
 | `--clickhouse.conn-max-lifetime` | `CLICKHOUSE_CONN_MAX_LIFETIME` | ClickHouse maximum connection lifetime. | `1h` |
-| `--clickhouse.max-idle-conns` | `CLICKHOUSE_MAX_IDLE_CONNS` | ClickHouse maximum number of idle connections. | `5` |
-| `--clickhouse.max-open-conns` | `CLICKHOUSE_MAX_OPEN_CONNS` | ClickHouse maximum number of open connections. | `10` |
+| `--clickhouse.max-idle-conns` | `CLICKHOUSE_MAX_IDLE_CONNS` | ClickHouse maximum number of idle connections. | `1` |
+| `--clickhouse.max-open-conns` | `CLICKHOUSE_MAX_OPEN_CONNS` | ClickHouse maximum number of open connections. | `1` |
 | `--clickhouse.async-insert` | `CLICKHOUSE_ASYNC_INSERT` | Enable async inserts. | `false` |
 | `--clickhouse.wait-for-async-insert` | `CLICKHOUSE_WAIT_FOR_ASYNC_INSERT` | Wait for async inserts. | `false` |
 | `--clickhouse.batch-size` | `CLICKHOUSE_BATCH_SIZE` | The size for how many log lines should be buffered, before they are written to ClickHouse. | `100000` |

--- a/cmd/ingester/main.go
+++ b/cmd/ingester/main.go
@@ -78,7 +78,7 @@ func init() {
 		defaultClickHouseConnMaxLifetime = os.Getenv("CLICKHOUSE_CONN_MAX_LIFETIME")
 	}
 
-	defaultClickHouseMaxIdleConns := 5
+	defaultClickHouseMaxIdleConns := 1
 	if os.Getenv("CLICKHOUSE_MAX_IDLE_CONNS") != "" {
 		defaultClickHouseMaxIdleConnsString := os.Getenv("CLICKHOUSE_MAX_IDLE_CONNS")
 		defaultClickHouseMaxIdleConnsParsed, err := strconv.Atoi(defaultClickHouseMaxIdleConnsString)
@@ -87,7 +87,7 @@ func init() {
 		}
 	}
 
-	defaultClickHouseMaxOpenConns := 10
+	defaultClickHouseMaxOpenConns := 1
 	if os.Getenv("CLICKHOUSE_MAX_OPEN_CONNS") != "" {
 		defaultClickHouseMaxOpenConnsString := os.Getenv("CLICKHOUSE_MAX_OPEN_CONNS")
 		defaultClickHouseMaxOpenConnsParsed, err := strconv.Atoi(defaultClickHouseMaxOpenConnsString)

--- a/cmd/plugin/README.md
+++ b/cmd/plugin/README.md
@@ -16,8 +16,8 @@ An example configuration file can be found in the [fluent-bit-cm.yaml](../../clu
 | `Password` | The password, to authenticate to ClickHouse. | |
 | `Dial_Timeout` | ClickHouse dial timeout. | `10s` |
 | `Conn_Max_Lifetime` | ClickHouse maximum connection lifetime. | `1h` |
-| `Max_Idle_Conns` | ClickHouse maximum number of idle connections. | `5` |
-| `Max_Open_Conns` | ClickHouse maximum number of open connections. | `10` |
+| `Max_Idle_Conns` | ClickHouse maximum number of idle connections. | `1` |
+| `Max_Open_Conns` | ClickHouse maximum number of open connections. | `1` |
 | `Async_Insert` | Use async inserts to write logs into ClickHouse. | `false` |
 | `Wait_For_Async_Insert` | Wait for the async insert operation. | `false` |
 | `Batch_Size` | The size for how many log lines should be buffered, before they are written to ClickHouse. | `10000` |

--- a/cmd/plugin/main.go
+++ b/cmd/plugin/main.go
@@ -27,8 +27,8 @@ const (
 	defaultDatabase         string        = "logs"
 	defaultDialTimeout      string        = "10s"
 	defaultConnMaxLifetime  string        = "1h"
-	defaultMaxIdleConns     int           = 5
-	defaultMaxOpenConns     int           = 10
+	defaultMaxIdleConns     int           = 1
+	defaultMaxOpenConns     int           = 1
 	defaultBatchSize        int64         = 10000
 	defaultFlushInterval    time.Duration = 60 * time.Second
 	defaultForceUnderscores bool          = false


### PR DESCRIPTION
Change the default values for the max idle conns and max open conns in the ClickHouse connection pool. With our experience these values should fit better.