### PR TITLE
Add Metrics

### DIFF
--- a/cluster/fluent-bit/ingester/ingester.yaml
+++ b/cluster/fluent-bit/ingester/ingester.yaml
@@ -30,7 +30,7 @@ spec:
             - --log.format=json
             - --log.level=trace
           ports:
-            - containerPort: 8080
+            - containerPort: 2021
               name: http
           livenessProbe:
             httpGet:

--- a/cmd/ingester/README.md
+++ b/cmd/ingester/README.md
@@ -10,6 +10,7 @@ An example Deployment for the ClickHouse ingester can be found in the [ingester.
 
 | Command-Line Flag | Environment Variable | Description | Default |
 | ----------------- | -------------------- | ----------- | ------- |
+| `--metrics-server.address` | `METRICS_SERVER_ADDRESS` | The address, where the metrics server should listen on. | `:2021` |
 | `--clickhouse.address` | `CLICKHOUSE_ADDRESS` | ClickHouse address to connect to. | |
 | `--clickhouse.database` | `CLICKHOUSE_DATABASE` | ClickHouse database name. | `logs` |
 | `--clickhouse.username` | `CLICKHOUSE_USERNAME` | ClickHouse username for the connection. | |

--- a/cmd/plugin/README.md
+++ b/cmd/plugin/README.md
@@ -10,6 +10,7 @@ An example configuration file can be found in the [fluent-bit-cm.yaml](../../clu
 
 | Option | Description | Default |
 | ------ | ----------- | ------- |
+| `Metrics_Server_Address` | The address, where the metrics server should listen on. | `:2021` |
 | `Address` | The address, where ClickHouse is listining on, e.g. `clickhouse-clickhouse.clickhouse.svc.cluster.local:9000`. | |
 | `Database` | The name of the database for the logs. | `logs` |
 | `Username` | The username, to authenticate to ClickHouse. | |

--- a/pkg/kafka/consumer.go
+++ b/pkg/kafka/consumer.go
@@ -11,24 +11,10 @@ import (
 	"github.com/kobsio/klogs/pkg/clickhouse"
 	flatten "github.com/kobsio/klogs/pkg/flatten/string"
 	"github.com/kobsio/klogs/pkg/log"
+	"github.com/kobsio/klogs/pkg/metrics"
 
 	"github.com/Shopify/sarama"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/zap"
-)
-
-var (
-	flushIntervalMetric = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "kafka_clickhouse",
-		Name:      "flush_interval_seconds",
-		Help:      "The flush interval describes after which time the messages from Kafka are written to ClickHouse",
-	})
-	batchSizeMetric = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "kafka_clickhouse",
-		Name:      "batch_size_count",
-		Help:      "The batch size describes how many messages from Kafka are written to ClickHouse",
-	})
 )
 
 // Consumer represents a Sarama consumer group consumer.
@@ -60,138 +46,143 @@ func (consumer *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, clai
 	// NOTE: Do not move the code below to a goroutine. The `ConsumeClaim` itself is called within a goroutine, see:
 	// https://github.com/Shopify/sarama/blob/main/consumer_group.go#L27-L29
 	for message := range claim.Messages() {
+		metrics.InputRecordsTotalMetric.Inc()
+
 		var record map[string]interface{}
 		record = make(map[string]interface{})
 
 		err := json.Unmarshal(message.Value, &record)
 		if err != nil {
+			metrics.ErrorsTotalMetric.Inc()
 			log.Error(nil, "Could not unmarshal log line", zap.Error(err))
-		}
+		} else {
+			data, err := flatten.Flatten(record)
+			if err != nil {
+				metrics.ErrorsTotalMetric.Inc()
+				log.Error(nil, "Could not flat data", zap.Error(err))
+			} else {
+				row := clickhouse.Row{
+					FieldsString: make(map[string]string),
+					FieldsNumber: make(map[string]float64),
+				}
 
-		data, err := flatten.Flatten(record)
-		if err != nil {
-			log.Error(nil, "Could not flat data", zap.Error(err))
-			break
-		}
+				for k, v := range data {
+					var stringValue string
+					var numberValue float64
+					var isNumber bool
+					var isNil bool
 
-		row := clickhouse.Row{
-			FieldsString: make(map[string]string),
-			FieldsNumber: make(map[string]float64),
-		}
-
-		for k, v := range data {
-			var stringValue string
-			var numberValue float64
-			var isNumber bool
-			var isNil bool
-
-			switch t := v.(type) {
-			case nil:
-				isNil = true
-			case string:
-				stringValue = t
-			case []byte:
-				stringValue = string(t)
-			case int:
-				isNumber = true
-				numberValue = float64(t)
-			case int8:
-				isNumber = true
-				numberValue = float64(t)
-			case int16:
-				isNumber = true
-				numberValue = float64(t)
-			case int32:
-				isNumber = true
-				numberValue = float64(t)
-			case int64:
-				isNumber = true
-				numberValue = float64(t)
-			case float32:
-				isNumber = true
-				numberValue = float64(t)
-			case float64:
-				isNumber = true
-				numberValue = float64(t)
-			case uint8:
-				isNumber = true
-				numberValue = float64(t)
-			case uint16:
-				isNumber = true
-				numberValue = float64(t)
-			case uint32:
-				isNumber = true
-				numberValue = float64(t)
-			case uint64:
-				isNumber = true
-				numberValue = float64(t)
-			default:
-				stringValue = fmt.Sprintf("%v", v)
-			}
-
-			if !isNil {
-				switch k {
-				case consumer.timestampKey:
-					parsedTime, err := strconv.ParseFloat(stringValue, 64)
-					if err != nil {
-						log.Warn(nil, "Could not parse timestamp, defaulting to now", zap.Error(err))
-						row.Timestamp = time.Now()
-					} else {
-						sec, dec := math.Modf(parsedTime)
-						row.Timestamp = time.Unix(int64(sec), int64(dec*(1e9)))
-					}
-				case "cluster":
-					row.Cluster = stringValue
-				case "kubernetes_namespace_name":
-					row.Namespace = stringValue
-				case "kubernetes_labels_k8s-app":
-					row.App = stringValue
-				case "kubernetes_labels_app":
-					row.App = stringValue
-				case "kubernetes_pod_name":
-					row.Pod = stringValue
-				case "kubernetes_container_name":
-					row.Container = stringValue
-				case "kubernetes_host":
-					row.Host = stringValue
-				case "log":
-					row.Log = stringValue
-				default:
-					formattedKey := k
-					if consumer.clickhouseForceUnderscores {
-						formattedKey = strings.ReplaceAll(k, ".", "_")
+					switch t := v.(type) {
+					case nil:
+						isNil = true
+					case string:
+						stringValue = t
+					case []byte:
+						stringValue = string(t)
+					case int:
+						isNumber = true
+						numberValue = float64(t)
+					case int8:
+						isNumber = true
+						numberValue = float64(t)
+					case int16:
+						isNumber = true
+						numberValue = float64(t)
+					case int32:
+						isNumber = true
+						numberValue = float64(t)
+					case int64:
+						isNumber = true
+						numberValue = float64(t)
+					case float32:
+						isNumber = true
+						numberValue = float64(t)
+					case float64:
+						isNumber = true
+						numberValue = float64(t)
+					case uint8:
+						isNumber = true
+						numberValue = float64(t)
+					case uint16:
+						isNumber = true
+						numberValue = float64(t)
+					case uint32:
+						isNumber = true
+						numberValue = float64(t)
+					case uint64:
+						isNumber = true
+						numberValue = float64(t)
+					default:
+						stringValue = fmt.Sprintf("%v", v)
 					}
 
-					if isNumber {
-						row.FieldsNumber[formattedKey] = numberValue
-					} else {
-						if contains(k, consumer.clickhouseForceNumberFields) {
-							parsedNumber, err := strconv.ParseFloat(stringValue, 64)
-							if err == nil {
-								row.FieldsNumber[formattedKey] = parsedNumber
+					if !isNil {
+						switch k {
+						case consumer.timestampKey:
+							parsedTime, err := strconv.ParseFloat(stringValue, 64)
+							if err != nil {
+								log.Warn(nil, "Could not parse timestamp, defaulting to now", zap.Error(err))
+								row.Timestamp = time.Now()
 							} else {
-								row.FieldsString[formattedKey] = stringValue
+								sec, dec := math.Modf(parsedTime)
+								row.Timestamp = time.Unix(int64(sec), int64(dec*(1e9)))
 							}
-						} else {
-							row.FieldsString[formattedKey] = stringValue
+						case "cluster":
+							row.Cluster = stringValue
+						case "kubernetes_namespace_name":
+							row.Namespace = stringValue
+						case "kubernetes_labels_k8s-app":
+							row.App = stringValue
+						case "kubernetes_labels_app":
+							row.App = stringValue
+						case "kubernetes_pod_name":
+							row.Pod = stringValue
+						case "kubernetes_container_name":
+							row.Container = stringValue
+						case "kubernetes_host":
+							row.Host = stringValue
+						case "log":
+							row.Log = stringValue
+						default:
+							formattedKey := k
+							if consumer.clickhouseForceUnderscores {
+								formattedKey = strings.ReplaceAll(k, ".", "_")
+							}
+
+							if isNumber {
+								row.FieldsNumber[formattedKey] = numberValue
+							} else {
+								if contains(k, consumer.clickhouseForceNumberFields) {
+									parsedNumber, err := strconv.ParseFloat(stringValue, 64)
+									if err == nil {
+										row.FieldsNumber[formattedKey] = parsedNumber
+									} else {
+										row.FieldsString[formattedKey] = stringValue
+									}
+								} else {
+									row.FieldsString[formattedKey] = stringValue
+								}
+							}
 						}
 					}
 				}
-			}
-		}
 
-		consumer.clickhouseClient.BufferAdd(row)
-		session.MarkMessage(message, "")
+				consumer.clickhouseClient.BufferAdd(row)
+				session.MarkMessage(message, "")
+				startFlushTime := time.Now()
+				currentBatchSize := consumer.clickhouseClient.BufferLen()
 
-		if consumer.clickhouseClient.BufferLen() >= int(consumer.clickhouseBatchSize) || consumer.lastFlush.Add(consumer.clickhouseFlushInterval).Before(time.Now()) {
-			flushIntervalMetric.Set(time.Now().Sub(consumer.lastFlush).Seconds())
-			batchSizeMetric.Set(float64(consumer.clickhouseClient.BufferLen()))
-
-			err := consumer.clickhouseClient.BufferWrite()
-			if err != nil {
-				log.Error(nil, "Could nor write buffer", zap.Error(err))
-			} else {
-				consumer.lastFlush = time.Now()
+				if currentBatchSize >= int(consumer.clickhouseBatchSize) || consumer.lastFlush.Add(consumer.clickhouseFlushInterval).Before(time.Now()) {
+					err := consumer.clickhouseClient.BufferWrite()
+					if err != nil {
+						metrics.ErrorsTotalMetric.Inc()
+						log.Error(nil, "Could nor write buffer", zap.Error(err))
+					} else {
+						consumer.lastFlush = time.Now()
+						metrics.BatchSizeMetric.Observe(float64(currentBatchSize))
+						metrics.FlushTimeSecondsMetric.Observe(consumer.lastFlush.Sub(startFlushTime).Seconds())
+					}
+				}
 			}
 		}
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,93 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/kobsio/klogs/pkg/log"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap"
+)
+
+var (
+	InputRecordsTotalMetric = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "klogs",
+		Name:      "input_records_total",
+		Help:      "Number of received records.",
+	})
+	ErrorsTotalMetric = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "klogs",
+		Name:      "errors_total",
+		Help:      "Number of errors when writing records to ClickHouse",
+	})
+	BatchSizeMetric = promauto.NewSummary(prometheus.SummaryOpts{
+		Namespace:  "klogs",
+		Name:       "batch_size",
+		Help:       "The number of records which are written to ClickHouse.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001},
+	})
+	FlushTimeSecondsMetric = promauto.NewSummary(prometheus.SummaryOpts{
+		Namespace:  "klogs",
+		Name:       "flush_time_seconds",
+		Help:       "The time needed to write the records in seconds.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001},
+	})
+)
+
+// Server is the interface of a metrics service, which provides the options to start and stop the underlying http
+// server.
+type Server interface {
+	Start()
+	Stop()
+}
+
+// server implements the Server interface.
+type server struct {
+	*http.Server
+}
+
+// Start starts serving the metrics server.
+func (s *server) Start() {
+	log.Info(nil, "Metrics server started", zap.String("address", s.Addr))
+
+	if err := s.ListenAndServe(); err != nil {
+		if err != http.ErrServerClosed {
+			log.Error(nil, "Metrics server died unexpected", zap.Error(err))
+		}
+	}
+}
+
+// Stop terminates the metrics server gracefully.
+func (s *server) Stop() {
+	log.Debug(nil, "Start shutdown of the metrics server")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := s.Shutdown(ctx)
+	if err != nil {
+		log.Error(nil, "Graceful shutdown of the metrics server failed", zap.Error(err))
+	}
+}
+
+// New return a new metrics server, which is used to serve Prometheus metrics on the specified address under the
+// /metrics path.
+func New(address string) Server {
+	router := http.DefaultServeMux
+	router.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "OK")
+	})
+	router.Handle("/metrics", promhttp.Handler())
+
+	return &server{
+		&http.Server{
+			Addr:    address,
+			Handler: router,
+		},
+	}
+}


### PR DESCRIPTION
klogs exports the following metrics now:

- "klogs_input_records_total": The number of received records from Fluent Bit / Kafka.
- "klogs_errors_total": The number of errors when writing logs to ClickHouse or receiving messages from Kafka.
- "klogs_batch_size": The number of logs written to ClickHouse in one write.
- "klogs_flush_time_seconds": The time in seconds needed to write logs to ClickHouse.

The metrics server is listining on ":2021" per default. This can be changed via the "Metrics_Server_Address" setting or the "--metrics-server.address" flag in the ingester.