### PR TITLE
Call Rollback when Transaction Failed

### DIFF
--- a/pkg/clickhouse/clickhouse.go
+++ b/pkg/clickhouse/clickhouse.go
@@ -77,6 +77,8 @@ func (c *Client) BufferWrite() error {
 		return err
 	}
 
+	defer tx.Rollback()
+
 	stmt, err := tx.Prepare(sql)
 	if err != nil {
 		log.Error(nil, "Prepare statement failure", zap.Error(err))


### PR DESCRIPTION
We didn't call "tx.Rollback()" to abort a transaction, which could caused a bug, that the plugin stopped working. This should be fixed be calling "tx.Rollback()" via defer, so that it is always executed in case of a failure. When the transaction was successfull it is also called, but didn't do anything.