### PR TITLE
Use GitHub Container Registry instead of Docker Hub

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -1,4 +1,4 @@
-name: Docker
+name: Continuous Delivery
 
 on:
   push:
@@ -10,7 +10,10 @@ on:
 jobs:
   plugin:
     name: Plugin
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -21,11 +24,10 @@ jobs:
         id: tag
         run: |
           if [[ $GITHUB_REF == refs/tags/* ]]; then
-            DOCKER_TAG="${GITHUB_REF:10}"
+            echo TAG=${GITHUB_REF:10} >> $GITHUB_ENV
           else
-            DOCKER_TAG="main"
+            echo TAG=main >> $GITHUB_ENV
           fi
-          echo ::set-output name=tag::${DOCKER_TAG}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -36,8 +38,9 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
 
       - name: Build and Push Docker Image
         id: docker_build
@@ -47,11 +50,14 @@ jobs:
           context: .
           file: ./cmd/plugin/Dockerfile
           platforms: linux/amd64,linux/arm,linux/arm64
-          tags: kobsio/klogs:${{ steps.tag.outputs.tag }}-plugin
+          tags: ghcr.io/${{ github.repository_owner }}/klogs:${{ env.TAG }}-plugin
 
   ingester:
     name: Ingester
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -62,11 +68,10 @@ jobs:
         id: tag
         run: |
           if [[ $GITHUB_REF == refs/tags/* ]]; then
-            DOCKER_TAG="${GITHUB_REF:10}"
+            echo TAG=${GITHUB_REF:10} >> $GITHUB_ENV
           else
-            DOCKER_TAG="main"
+            echo TAG=main >> $GITHUB_ENV
           fi
-          echo ::set-output name=tag::${DOCKER_TAG}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -77,8 +82,9 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
 
       - name: Build and Push Docker Image
         id: docker_build
@@ -88,4 +94,4 @@ jobs:
           context: .
           file: ./cmd/ingester/Dockerfile
           platforms: linux/amd64,linux/arm,linux/arm64
-          tags: kobsio/klogs:${{ steps.tag.outputs.tag }}-ingester
+          tags: ghcr.io/${{ github.repository_owner }}/klogs:${{ env.TAG }}-ingester

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,12 +1,17 @@
-name: Test
+name: Continuous Integration
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-20.04
+  go:
+    name: Go
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -16,25 +21,21 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
-
-      - name: Cache Go
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Download Dependencies
         run: |
           go mod download
 
+      - name: Vet
+        run: |
+          make vet
+
       - name: Test
         run: |
-          go test ./...
+          make test
 
       - name: Build Plugin
         run: |

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,11 @@ build-ingester:
 		-X ${REPO}/pkg/version.BuildUser=${BUILDUSER} \
 		-X ${REPO}/pkg/version.BuildDate=${BUILDTIME}" \
 		-o ingester ./cmd/ingester;
+
+.PHONY: vet
+vet:
+	@go vet ./...
+
+.PHONY: test
+test:
+	@go test ./...


### PR DESCRIPTION
Docker Hub will remove access for free organization on 14. April, so that we need a new container registry for our Docker images. Therefor we want to use GitHub Container Registry in the future (ghcr.io).

This commit also removes the depreacted "set-output" command and replaces it with the recommended way from
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/