### PR TITLE
Revert Docker Image Updates

### DIFF
--- a/cluster/fluent-bit/ingester/fluent-bit-ds.yaml
+++ b/cluster/fluent-bit/ingester/fluent-bit-ds.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: fluent-bit
       serviceAccount: fluent-bit
       containers:
-        - image: fluent/fluent-bit:2.1.7
+        - image: fluent/fluent-bit:2.0.9
           imagePullPolicy: IfNotPresent
           name: fluent-bit
           ports:

--- a/cmd/plugin/Dockerfile
+++ b/cmd/plugin/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.20.6 as build
+FROM golang:1.20.2 as build
 WORKDIR /root
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN make build-plugin
 
-FROM fluent/fluent-bit:2.1.7
+FROM fluent/fluent-bit:2.0.9
 COPY --from=build /root/out_clickhouse.so /fluent-bit/bin/
 EXPOSE 2020
 CMD ["/fluent-bit/bin/fluent-bit", "--plugin", "/fluent-bit/bin/out_clickhouse.so", "--config", "/fluent-bit/etc/fluent-bit.conf"]


### PR DESCRIPTION
When the current Docker image for the Fluent Bit plugin is run it throws the following error:

```
[2023/07/26 08:21:38] [error] [proxy] error opening plugin /fluent-bit/bin/out_clickhouse.so: '/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /fluent-bit/bin/out_clickhouse.so)'
[2023/07/26 08:21:38] [error] [plugin] error loading proxy plugin: /fluent-bit/bin/out_clickhouse.so
```

Also the output plugin doesn't work with the new record format yet, see
https://github.com/fluent/fluent-bit-go/issues/66